### PR TITLE
fix: set public access to enable npm public release

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "dependencies": {
     "aws-sdk": "^2.600.0",
     "gatsby-source-filesystem": "^2.1.46"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
From https://semantic-release.gitbook.io/semantic-release/support/faq#how-can-i-set-the-access-level-of-the-published-npm-package