### PR TITLE
fix: avoid array.prototype.flat

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -50,13 +50,16 @@ export async function sourceNodes(
   };
 
   try {
-    const objects = await Promise.all(
+    let objects: Array<any> = await Promise.all(
       buckets.map(bucket => listObjects(bucket))
     );
+    // flatten objects
+    // flat() is not supported in node 10
+    objects = [].concat(...objects);
 
     // create file nodes
     // todo touch nodes if they exist already
-    objects?.flat().forEach(async object => {
+    objects?.forEach(async object => {
       const { Key, Bucket } = object;
       const { region } = awsConfig;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": ["ES2018"],
     "module": "CommonJS",
     // support node 10 and newer
     "target": "ES2018",


### PR DESCRIPTION
Update tsconfig to reflect that we are using ES2018 (Node 10). Array.prototype.flat is only available in Node 11. Instead of using a polyfill, we will use concat to flatten the array of object arrays