### PR TITLE
adds ContinuationToken and extra error handling

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -39,7 +39,7 @@ export async function sourceNodes(
       });
   }
 
-  const listAllS3Items = async (bucket) => {
+  const listAllS3Items = async (bucket: string) => {
     const allS3Items = [];
 
     const data = await getS3ListObjects({ Bucket: bucket });

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -77,7 +77,7 @@ export async function sourceNodes(
   };
 
   try {
-    const allBucketsObjects: Array<any> = await Promise.all(
+    const allBucketsObjects: ObjectType[][] = await Promise.all(
       buckets.map(bucket => listAllS3Objects(bucket))
     );
 

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -44,7 +44,7 @@ export async function sourceNodes(
 
     const data = await getS3ListObjects({ Bucket: bucket });
 
-    if (data && data.Contents) {
+    if (data?.Contents) {
       data.Contents.forEach((content) => {
         allS3Items.push({ ...content, Bucket: bucket });
       });

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -40,7 +40,7 @@ export async function sourceNodes(
   }
 
   const listAllS3Items = async (bucket: string) => {
-    const allS3Items = [];
+    const allS3Items: ObjectType[] = [];
 
     const data = await getS3ListObjects({ Bucket: bucket });
 

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -32,7 +32,7 @@ export async function sourceNodes(
     return await s3.listObjectsV2(params)
       .promise()
       .catch((error) => {
-        throw new Error('Problem getting S3 list objects.', error)
+        reporter.error(`Error listing S3 objects on bucket "${params.Bucket}": ${error}`)
       });
   }
 

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -28,7 +28,10 @@ export async function sourceNodes(
   // get objects
   const s3 = new AWS.S3();
 
-  const getS3ListObjects = async (params) => {
+  const getS3ListObjects = async (params: {
+    Bucket: string;
+    ContinuationToken?: string;
+  }) => {
     return await s3.listObjectsV2(params)
       .promise()
       .catch((error) => {

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -46,7 +46,7 @@ export async function sourceNodes(
         allS3Items.push({ ...content, Bucket: bucket });
       });
     } else {
-      throw new Error(`bucket '${bucket}' is empty`)
+      reporter.error(`Error processing objects from bucket "${bucket}". Is it empty?`)
     }
 
     let nextToken = data && data.IsTruncated && data.NextContinuationToken;

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -77,7 +77,7 @@ export async function sourceNodes(
   };
 
   try {
-    const allBucketsObjects = await Promise.all(
+    const allBucketsObjects: Array<any> = await Promise.all(
       buckets.map(bucket => listAllS3Objects(bucket))
     );
 

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -47,7 +47,7 @@ export async function sourceNodes(
 
     const data = await getS3ListObjects({ Bucket: bucket });
 
-    if (data?.Contents) {
+    if (data && data.Contents) {
       data.Contents.forEach(object => {
         allS3Objects.push({ ...object, Bucket: bucket });
       });

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -96,7 +96,7 @@ export async function sourceNodes(
         // construct url
         Url: `https://s3.${
           region ? `${region}.` : ""
-          }amazonaws.com/${Bucket}/${Key}`,
+        }amazonaws.com/${Bucket}/${Key}`,
         // node meta
         id: createNodeId(`s3-object-${Key}`),
         parent: null,


### PR DESCRIPTION
S3 has a limit of 1000 objects that can be retrieved in a single request. [AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html)

- Handles NextContinuationToken for multiple buckets
- Extra error handling

@robinmetral I'm not familiar with writing TS (I should have learnt it by now 🤓) so I would appreciate any input.