### PR TITLE
fix: use plugin options for AWS config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         run: yarn lint
       - name: E2E
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID_: ${{ secrets.AWS_ACCESS_KEY_ID_ }}
+          AWS_SECRET_ACCESS_KEY_: ${{ secrets.AWS_SECRET_ACCESS_KEY_ }}
+          AWS_REGION_: ${{ secrets.AWS_REGION_ }}
         run: yarn e2e

--- a/examples/gatsby-starter-source-s3/gatsby-config.js
+++ b/examples/gatsby-starter-source-s3/gatsby-config.js
@@ -9,9 +9,9 @@ module.exports = {
       resolve: `@robinmetral/gatsby-source-s3`,
       options: {
         aws: {
-          accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-          region: process.env.AWS_REGION,
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID_,
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY_,
+          region: process.env.AWS_REGION_,
         },
         buckets: [
           "gatsby-source-s3-example",

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -1,8 +1,6 @@
 import { createRemoteFileNode } from "gatsby-source-filesystem";
 import AWS = require("aws-sdk");
 
-const s3 = new AWS.S3();
-
 const isImage = (key: string): boolean =>
   /\.(jpe?g|png|webp|tiff?)$/i.test(key);
 
@@ -26,6 +24,7 @@ export async function sourceNodes(
 
   // configure aws
   AWS.config.update(awsConfig);
+  const s3 = new AWS.S3();
 
   // get objects
   const getS3ListObjects = async (params: {
@@ -87,10 +86,19 @@ export async function sourceNodes(
 
     // create file nodes
     objects?.forEach(async (object) => {
+      const { Bucket, Key } = object;
+      // get pre-signed URL
+      const url = s3.getSignedUrl("getObject", {
+        Bucket,
+        Key,
+        Expires: 60,
+      });
+
       createNode({
         ...object,
+        url,
         // node meta
-        id: createNodeId(`s3-object-${object.Key}`),
+        id: createNodeId(`s3-object-${Key}`),
         parent: null,
         children: [],
         internal: {
@@ -115,16 +123,9 @@ export async function onCreateNode({
 }) {
   if (node.internal.type === "S3Object" && node.Key && isImage(node.Key)) {
     try {
-      // get pre-signed URL
-      const url = s3.getSignedUrl("getObject", {
-        Bucket: node.Bucket,
-        Key: node.Key,
-        Expires: 60,
-      });
-
       // download image file and save as node
       const imageFile = await createRemoteFileNode({
-        url,
+        url: node.url,
         parentNodeId: node.id,
         store,
         cache,


### PR DESCRIPTION
Version `2.0.0` introduced a bug where the plugin wouldn't work if your environment variables aren't the "official" ones from AWS CLI:

- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `AWS_REGION`

The configuration was not working (presumably because it wasn't updated in `onCreateNode`), and therefore AWS had to fall back on the environment variables.

In some cases, these "official" names are reserved (for example when deploying to Netlify), which means that the plugin would fail to configure AWS and the calls return a 400.

This PR addresses the issue by:

- reverting to setting the AWS configuration only in `sourceNodes` and passing the pre-signed URLs over to `onCreateNode` by adding it to the `s3Object` schema.
- changing the environment variables names in the example site to make sure that AWS config issues are caught by the CI in the future.