### PR TITLE
Add option "expiration" to extend signed requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ module.exports = {
           region: process.env.AWS_REGION,
         },
         buckets: ["my-bucket", "my-second-bucket"],
-        //expiration: 120,
+        expiration: 120,
       },
     },
   ],

--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ module.exports = {
           region: process.env.AWS_REGION,
         },
         buckets: ["my-bucket", "my-second-bucket"],
+        //expiration: 120,
       },
     },
   ],
 };
 ```
+
+The value of expiration specifies the time after which signed requests to S3 will expire. The default value is 60 seconds. Feel free to increase if you have many or large images and start to see errors similar to "HTTPError: Response code 403 (Forbidden)" during build. This option is not compulsory.
 
 ### AWS setup
 

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -11,6 +11,7 @@ type pluginOptionsType = {
     region: string;
   };
   buckets: string[];
+  expiration: number;
 };
 
 type ObjectType = AWS.S3.Object & { Bucket: string };
@@ -20,7 +21,7 @@ export async function sourceNodes(
   { actions: { createNode }, createNodeId, createContentDigest, reporter },
   pluginOptions: pluginOptionsType
 ) {
-  const { aws: awsConfig, buckets } = pluginOptions;
+  const { aws: awsConfig, buckets, expiration = 60 } = pluginOptions;
 
   // configure aws
   AWS.config.update(awsConfig);
@@ -91,7 +92,7 @@ export async function sourceNodes(
       const url = s3.getSignedUrl("getObject", {
         Bucket,
         Key,
-        Expires: 60,
+        Expires: expiration,
       });
 
       createNode({


### PR DESCRIPTION
Due to the number or size of the processed S3 files it can happen that the "Expires" period of 60 seconds is exceeded, causing a barrage of 403 errors. Let's make this value configurable to solve such cases. This PR resolves #237.