### PR TITLE
ci: fix event triggers to run CI on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Note: this effectively reverts a previous change that was made to avoid running duplicated workflows for branches (push and pull_request). I'm not sure how to make sure the workflow runs just once and on both this repo and on forks, so going back to the duplicated runs for now.