### PR TITLE
fix: increased default expires time to AWS pre-signed url operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ module.exports = {
 };
 ```
 
-The value of expiration specifies the time after which signed requests to S3 will expire. The default value is 60 seconds. Feel free to increase if you have many or large images and start to see errors similar to "HTTPError: Response code 403 (Forbidden)" during build. This option is not compulsory.
+The value of expiration specifies the time after which signed requests to S3 will expire. The default value is 15 minutes (the default for AWS pre-signed URL operations). Feel free to increase if you have many or large images and start to see errors similar to "HTTPError: Response code 403 (Forbidden)" during build. This option is not compulsory.
 
 ### AWS setup
 

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -21,7 +21,7 @@ export async function sourceNodes(
   { actions: { createNode }, createNodeId, createContentDigest, reporter },
   pluginOptions: pluginOptionsType
 ) {
-  const { aws: awsConfig, buckets, expiration = 60 } = pluginOptions;
+  const { aws: awsConfig, buckets, expiration = 900 } = pluginOptions;
 
   // configure aws
   AWS.config.update(awsConfig);


### PR DESCRIPTION
Duplicate PR - I messed up my folk rebase on previous PR.

I believe we should increase the default expires time to match AWS. 

```
Expires (Integer) — default: 900 — the number of seconds to expire the pre-signed URL operation in. Defaults to 15 minutes.
```
from [AWS getSignedUrl Docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getSignedUrl-property)

This new feature broke my websites as it was a change to the interface (with a default) - should have probably been a major version. A great feature to add though, Thanks.