### PR TITLE
fix(ci): do not depend on gatsby-cli and update env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,14 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
       - name: Install dependencies
         run: yarn install
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,14 @@ on: [push, pull_request]
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
       - name: Install dependencies
         run: yarn install
       - name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   test:
     name: Test

--- a/examples/gatsby-starter-source-s3/package.json
+++ b/examples/gatsby-starter-source-s3/package.json
@@ -13,5 +13,10 @@
     "gatsby-transformer-sharp": "^3.13.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
+  },
+  "scripts": {
+    "develop": "gatsby develop",
+    "build": "gatsby build",
+    "serve": "gatsby serve"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build": "tsc",
     "lint": "eslint '*/**/*.{ts,tsx}'",
     "prestart": "yarn build && npm pack && (cd examples/gatsby-starter-source-s3 && yarn install)",
-    "start": "(cd examples/gatsby-starter-source-s3 && gatsby build && gatsby serve)",
+    "start": "(cd examples/gatsby-starter-source-s3 && yarn build && yarn serve)",
     "start:local": "yarn cache clean && (cd examples/gatsby-starter-source-s3 && rm -rf node_modules .cache public yarn.lock) && yarn start",
     "test": "cypress run",
     "e2e": "start-server-and-test http://localhost:9000"

--- a/release.config.js
+++ b/release.config.js
@@ -3,7 +3,7 @@ module.exports = {
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/npm",
-    "@semantic-release/github"
+    "@semantic-release/github",
   ],
-  preset: "conventionalcommits"
+  preset: "conventionalcommits",
 };


### PR DESCRIPTION
This PR fixes a few things around the CI environment (including the example Gatsby site used for e2e testing):

- Update CI env (Ubuntu and Node versions)
- Remove dependency on global gatsby installation (`gatsby-cli`), run gatsby via local `node_modules` instead
- Fix the number of CI runs for PRs from main repo branches (mentioned in #282). Using `push` would not run fork PRs, and using `pull_request` would not run merges to `master`, so we run both with config