### PR TITLE
fix(ci): fix release branch config and move to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,17 @@
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
+  },
+  "release": {
+    "branches": [
+      "main"
+    ],
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
+      "@semantic-release/github"
+    ],
+    "preset": "conventionalcommits"
   }
 }

--- a/release.config.js
+++ b/release.config.js
@@ -1,9 +1,0 @@
-module.exports = {
-  plugins: [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
-    "@semantic-release/github",
-  ],
-  preset: "conventionalcommits",
-};


### PR DESCRIPTION
- add `{ "branches": ["main"] }` to the semantic release config to run on `main`
- move the semantic release config to `package.json` to align with other configs (husky)